### PR TITLE
Set max rows to a more reasonable number

### DIFF
--- a/ipypandex/__init__.py
+++ b/ipypandex/__init__.py
@@ -1,3 +1,3 @@
 import pandas as pd
 pd.options.display.html.table_schema = True
-pd.options.display.max_rows = None
+pd.options.display.max_rows = 100000


### PR DESCRIPTION
Let's not crash notebooks by loading _everything_, but mostly everything